### PR TITLE
Add image verification to icon update process

### DIFF
--- a/TvLauncher_Linux.py
+++ b/TvLauncher_Linux.py
@@ -18,6 +18,7 @@ from PyQt6.QtCore import (
 )
 from PyQt6.QtGui import QPixmap, QFont, QKeyEvent, QPainter, QColor, QIcon , QBrush
 import psutil
+import puremagic
 
 from modules.app_reorder import integrate_reorder_mode
 from modules.search_widget import QuickSearchWidget
@@ -1038,7 +1039,7 @@ class TVLauncher(QMainWindow):
                 needs_update = True
             elif icon_path == app_path:
                 needs_update = True
-            elif icon_path.lower().endswith('.exe'):
+            elif not self.is_image_or_icon(icon_path):
                 needs_update = True
             elif not Path(icon_path).exists():
                 needs_update = True
@@ -1080,6 +1081,34 @@ class TVLauncher(QMainWindow):
         self.progress_dialog.canceled.connect(self.cover_download_worker.stop)
         self.cover_download_worker.start()
         self.progress_dialog.show()
+
+    def is_image_or_icon(self, path: str) -> bool:
+        """
+        Checks if a file is likely an image or icon using:
+        1. Content-based MIME detection via puremagic
+        2. Fallback to common image/icon extensions
+        """
+        if not os.path.isfile(path) or os.path.getsize(path) == 0:
+            return False
+
+        # ── Content-based check (most reliable) ──
+        try:
+            mime_type = puremagic.from_file(path, mime=True)
+            if mime_type and mime_type.startswith('image/'):
+                return True
+        except puremagic.PureError:
+            pass
+        except OSError:
+            return False
+
+        ext = os.path.splitext(path)[1].lower()
+        image_extensions = {
+            '.png', '.jpg', '.jpeg', '.jpe', '.jfif',
+            '.gif', '.bmp', '.webp', '.tiff', '.tif',
+            '.ico', '.cur', '.svg', '.xpm', '.icns',
+            '.apng', '.avif', '.heic', '.heif',
+        }
+        return ext in image_extensions
 
     def _on_cover_download_progress(self, message, percent):
         if self.progress_dialog:

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,6 @@ PyQt6>=6.4.0
 psutil>=5.9.0
 pygame>=2.5.0
 requests>=2.28.0
+puremagic>=2.1.0,<3.0.0
 
 


### PR DESCRIPTION
Hi 
I had the problem that the flatpak binary path (/usr/bin/flatpak) was added as icon path for all flatpaks (like rocks.shy.VacuumTube). 
As a consequence the cover was not downloaded from the steamgriddb because the path was valid.

To fix this I added a check if the file in the icon path is really an image with the puremagic package (https://pypi.org/project/puremagic/). it worked fine in my tests.

ps: love your project. I work on a tv box setup (https://github.com/schumischumi/tvbox-ansible) and it saves a lot of work and looks better than everything i would create^^